### PR TITLE
Removed the never occurring string return

### DIFF
--- a/src/socket-as-promised.ts
+++ b/src/socket-as-promised.ts
@@ -169,7 +169,7 @@ export class SocketAsPromised implements AsyncIterable<IncomingPacket> {
     })
   }
 
-  address(): AddressInfo | string {
+  address(): AddressInfo {
     return this.socket.address()
   }
 


### PR DESCRIPTION
As far as I'm aware [`socket.address()`](https://nodejs.org/api/dgram.html#dgram_socket_address) never returns a `string`.
Removing this from the signature would prevent an unnecessary cast or typecheck when using the exposed method.
(Unless I'm overseeing something, in which case: please educate me)